### PR TITLE
Use inverse NStudents

### DIFF
--- a/pedagogy_exam_analysis.qmd
+++ b/pedagogy_exam_analysis.qmd
@@ -45,7 +45,7 @@ ped |>
   geom_point(aes(x = Exam1, color = Semester))
 ```
 
-
+# Basic lm model
 ```{r}
 ped.lm <- lm(Final ~ .  , data = ped)
 summary(ped.lm)
@@ -66,17 +66,20 @@ ped |>
 lmtest::bptest(ped.lm)
 ```
 
+# GLS model
 ```{r}
+
 ped.gls <- gls(model=Final~. ,
     data=ped,
-    weights=varFixed(~NStudents),
+    weights=varFixed(~1/NStudents),
     method="ML")
 
 summary(ped.gls)
 ```
-## Check assumptions
 
-#### Linearity
+# GLS assumptions
+
+### Linearity
 
 ```{r}
 car::avPlots(ped.lm)
@@ -84,11 +87,11 @@ car::avPlots(ped.lm)
 
 The only added-variable plot between Income and EatingOut appears linear. This assumption is met.
 
-#### Independence
+### Independence
 
 It's likely safe to assume that the 523 households from this survey were randomly selected, but since it doesn't specify that they were, we must examine the data more deeply. Since the average weekly expenditure on ped not cooked at home for a family does not usually depend on the average weekly expenditure on ped not cooked at home of another family, we can assume these responses are independent. This assumption is met.
 
-#### Normality
+### Normality
 
 ```{r message=FALSE}
 ggplot(data = data.frame(residual = resid(ped.gls, type="pearson")),
@@ -105,9 +108,7 @@ ks.test(resid(ped.gls, type="pearson"), "pnorm")
 
 The KS-test outputs a large p-value (meaning we have insufficient evidence to say anything except that residuals are normally distributed), and the histogram looks approximately normal. This assumption is met.
 
-
-
-#### Equal Variance
+### Equal Variance
 
 ```{r message=FALSE}
 ggplot(data = data.frame(residual = resid(ped.gls, type="pearson")),
@@ -125,10 +126,9 @@ lmtest::bptest((resid(ped.gls, type="pearson"))^2 ~ fitted(ped.gls))
 
 The BP-test outputs a large p-value, and the scatter plot of fitted v. standardized residuals appears to have constant variance. This assumption is now met.
 
+# Cross Validation 
 
-
-### Leave-one-out Cross Validation
-
+## Leave One Out
 ```{r}
 n <- nrow(ped)
 rpmse <- rep(x=NA, times=n)
@@ -149,7 +149,7 @@ for(i in 1:n){
   ## Fit a lm() using the training data
   train.gls <- gls(model=Final~. ,
     data=train.set,
-    weights=varFixed(~NStudents),
+    weights=varFixed(~1/NStudents),
     method="ML")
   
   ## Generate predictions for the test set
@@ -174,7 +174,7 @@ for(i in 1:n){
 }
 ```
 
-
+## CV Results
 ```{r}
 # RPMSE
 hist(rpmse, main="RPMSE Histogram", xlab="RPMSE")
@@ -201,6 +201,7 @@ hist(wid, main="Width Histogram", xlab="Width")
 mean(wid)
 ```
 
+## CV Prediction Plots
 ```{r}
 dataPreds <- predictgls(glsobj=ped.gls, level=0.95, newdframe=ped)
 ggplot() + 
@@ -215,20 +216,18 @@ ggplot() +
             mapping=aes(x=Exam3, y=upr), 
             color="red", linetype="dashed") #Upper bound
 
-ggplot() + 
-  geom_point(data=dataPreds, 
+ggplot() +
+  geom_point(data=dataPreds,
              mapping=aes(x=Exam2, y=Final)) + #Scatterplot
-  geom_line(data=dataPreds, 
+  geom_line(data=dataPreds,
             mapping=aes(x=Exam2, y=Prediction)) + #Prediction Line
-  geom_line(data=dataPreds, 
-            mapping=aes(x=Exam2, y=lwr), 
+  geom_line(data=dataPreds,
+            mapping=aes(x=Exam2, y=lwr),
             color="red", linetype="dashed") + #lwr bound
-  geom_line(data=dataPreds, 
-            mapping=aes(x=Exam2, y=upr), 
+  geom_line(data=dataPreds,
+            mapping=aes(x=Exam2, y=upr),
             color="red", linetype="dashed") #Upper bound
 ```
-
-
 
 # Hypothesis Testing and Confidence Intervals under Heteroskedasticity
 
@@ -243,9 +242,11 @@ summary(ped.gls)$sigma # estimate of s
 
 
 ```
-IT appears that the significant factors are Exam 3 and Exam 2. 
+
+IT appears that the significant factors are Exam 3 and Exam 2.
 
 *Carry out a hypothesis test that beta_Quiz=0 . Carry out a hypothesis test that beta_HW=0 Report the p -value and draw an appropriate conclusion.*
+
 ```{r}
 a <- matrix(c(0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1), nrow=1)
 summary(multcomp::glht(ped.gls, linfct=a, rhs=0))
@@ -253,21 +254,20 @@ summary(multcomp::glht(ped.gls, linfct=a, rhs=0))
 hw <- matrix(c(0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0), nrow=1)
 summary(multcomp::glht(ped.gls, linfct=hw, rhs=0))
 ```
-Because of a nonsignificant p value, we fail to reject the null that Beta_Quiz = 0. Therefore Quiz does not have a significant effect in our model. 
 
-
-
+Because of a nonsignificant p value, we fail to reject the null that Beta_Quiz = 0. Therefore Quiz does not have a significant effect in our model.
 
 Construct a 95% confidence interval for beta_Exam3 and beta_Exam2.
+
 ```{r}
 confint(ped.gls, level = 0.95)
 confint(ped.gls, level = 0.95)[13,] ## Exam 2
 confint(ped.gls, level = 0.95)[14,] ## Exam 3
 ```
 
-## RESEARCH Q NUM 4: 
-Historically, were there any semesters that had either better or worse student learning than average?
-Were there any semesters that were significantly different than another semester? 
+## RESEARCH Q NUM 4:
+
+Historically, were there any semesters that had either better or worse student learning than average? Were there any semesters that were significantly different than another semester?
 
 Does semester1=semester2=....=semester10? Hypothesis test...
 
@@ -286,5 +286,5 @@ ped %>%
 semester <- matrix(c(0,1,1,1,1,1,1,1,1,1,0,0,0,0,0,0), nrow=1)
 summary(multcomp::glht(ped.gls, linfct=semester, rhs=0))
 ```
-WIth a p value of 0.426 fail to reject there is a statistically significant semester... blah 
 
+WIth a p value of 0.426 fail to reject there is a statistically significant semester... blah


### PR DESCRIPTION
Based on the way Dr. Heaton explained the D matrix and the picture Anna sent from talking with him, I think we need to change the gls model specification for weights. 

This pull request changes `weights=varFixed(~1/NStudents)` instead of just being `varFixed(~NStudents)` for both our main model and the cross-validation.

Not much changed as far as our assumptions. The residual standard error did increase (not good, right?) but in the cross-validation stuff, the variance reduction thing we calculated and the correlation of the predictions with the actual values both increased. 

I also added a few more headers to make the outline a little easier to navigate.
